### PR TITLE
Add meditate start page skeleton

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,20 +1,23 @@
 import React from 'react';
-import { Button, Card } from '../../components/ui';
+import { Card } from '../../components/ui';
 import { SignInForm } from '../../components/auth/SignInForm';
 
 export default function MarketingPage() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-24">
-      <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm">
-        <h1 className="text-4xl font-bold text-center mb-8">
+    <div className='flex min-h-screen flex-col items-center justify-center p-24'>
+      <div className='z-10 max-w-5xl w-full items-center justify-between font-mono text-sm'>
+        <h1 className='text-4xl font-bold text-center mb-8'>
           AI Guru Meditation
         </h1>
-        <p className="text-center text-lg text-gray-600 mb-8">
-          A voice-first meditation app where users speak to an AI Guru who guides meditation in real time
+        <p className='text-center text-lg text-gray-600 mb-8'>
+          A voice-first meditation app where users speak to an AI Guru who
+          guides meditation in real time
         </p>
-        
-        <Card className="max-w-md mx-auto">
-          <h2 className="text-xl font-semibold mb-4 text-center">Get Started</h2>
+
+        <Card className='max-w-md mx-auto'>
+          <h2 className='text-xl font-semibold mb-4 text-center'>
+            Get Started
+          </h2>
           <SignInForm />
         </Card>
       </div>

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { createClient } from '../../../lib/supabaseServer';
 import { redirect } from 'next/navigation';
 
 export default async function AuthCallbackPage() {
   const supabase = createClient();
-  
+
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/app/meditate/page.tsx
+++ b/app/meditate/page.tsx
@@ -1,0 +1,66 @@
+import { Card } from '../../components/ui';
+import { Button } from '../../components/ui';
+
+export default function MeditatePage() {
+  return (
+    <div className='min-h-screen bg-gray-50 p-8'>
+      <div className='max-w-3xl mx-auto space-y-8'>
+        <header className='text-center space-y-2'>
+          <h1 className='text-3xl font-bold text-gray-900'>
+            Start a Meditation
+          </h1>
+          <p className='text-gray-600'>
+            Choose how you would like to begin your next session.
+          </p>
+        </header>
+
+        <div className='grid gap-6 md:grid-cols-2'>
+          <Card className='flex flex-col h-full justify-between space-y-4'>
+            <div className='space-y-2'>
+              <h2 className='text-xl font-semibold text-gray-900'>
+                Let Guru Decide
+              </h2>
+              <p className='text-gray-600'>
+                Answer a quick check-in and let the AI Guru pick the right
+                meditation technique for you.
+              </p>
+            </div>
+            <div className='space-y-2'>
+              <Button type='button' className='w-full' disabled>
+                Let Guru Decide
+              </Button>
+              <p className='text-sm text-gray-500 text-center'>
+                Flow coming soon
+              </p>
+            </div>
+          </Card>
+
+          <Card className='flex flex-col h-full justify-between space-y-4'>
+            <div className='space-y-2'>
+              <h2 className='text-xl font-semibold text-gray-900'>
+                Pick Technique
+              </h2>
+              <p className='text-gray-600'>
+                Browse the catalog of meditation styles and jump directly into a
+                live session.
+              </p>
+            </div>
+            <div className='space-y-2'>
+              <Button
+                type='button'
+                className='w-full'
+                variant='outline'
+                disabled
+              >
+                Pick Technique
+              </Button>
+              <p className='text-sm text-gray-500 text-center'>
+                Technique picker under construction
+              </p>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { redirect } from 'next/navigation';
 import { createClient } from '../lib/supabaseServer';
 
 export default async function Home() {
   const supabase = createClient();
-  
+
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/components/auth/SignInForm.tsx
+++ b/components/auth/SignInForm.tsx
@@ -39,21 +39,31 @@ export function SignInForm() {
 
   if (isSubmitted) {
     return (
-      <div className="text-center">
-        <div className="text-green-600 mb-4">
-          <svg className="w-16 h-16 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+      <div className='text-center'>
+        <div className='text-green-600 mb-4'>
+          <svg
+            className='w-16 h-16 mx-auto mb-4'
+            fill='none'
+            stroke='currentColor'
+            viewBox='0 0 24 24'
+          >
+            <path
+              strokeLinecap='round'
+              strokeLinejoin='round'
+              strokeWidth={2}
+              d='M5 13l4 4L19 7'
+            />
           </svg>
-          <h3 className="text-lg font-semibold">Check Your Email</h3>
+          <h3 className='text-lg font-semibold'>Check Your Email</h3>
         </div>
-        <p className="text-gray-600 mb-4">
-          We've sent a magic link to <strong>{email}</strong>
+        <p className='text-gray-600 mb-4'>
+          We’ve sent a magic link to <strong>{email}</strong>
         </p>
-        <p className="text-sm text-gray-500 mb-4">
+        <p className='text-sm text-gray-500 mb-4'>
           Click the link in your email to sign in. You can close this window.
         </p>
-        <Button 
-          variant="outline" 
+        <Button
+          variant='outline'
           onClick={() => {
             setIsSubmitted(false);
             setEmail('');
@@ -67,34 +77,35 @@ export function SignInForm() {
   }
 
   return (
-    <form onSubmit={handleSignIn} className="space-y-4">
+    <form onSubmit={handleSignIn} className='space-y-4'>
       <div>
-        <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+        <label
+          htmlFor='email'
+          className='block text-sm font-medium text-gray-700 mb-2'
+        >
           Email Address
         </label>
         <input
-          id="email"
-          type="email"
+          id='email'
+          type='email'
           value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          onChange={e => setEmail(e.target.value)}
           required
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          placeholder="Enter your email"
+          className='w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent'
+          placeholder='Enter your email'
         />
       </div>
-      
-      <Button 
-        type="submit" 
-        className="w-full" 
-        disabled={isLoading || !email}
-      >
+
+      <Button type='submit' className='w-full' disabled={isLoading || !email}>
         {isLoading ? 'Sending...' : 'Send Magic Link'}
       </Button>
-      
+
       {message && (
-        <div className={`text-sm text-center ${
-          message.includes('Error') ? 'text-red-600' : 'text-green-600'
-        }`}>
+        <div
+          className={`text-sm text-center ${
+            message.includes('Error') ? 'text-red-600' : 'text-green-600'
+          }`}
+        >
           {message}
         </div>
       )}


### PR DESCRIPTION
## Summary
- add the /meditate start page with placeholder actions for deciding or selecting a technique
- clean up unused imports and apostrophe usage so lint passes without warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcc59bbcb0833181c58bc43ad6951f