### PR TITLE
Add client-side meditation session flows

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,6 +1,15 @@
+'use client';
+
 import React from 'react';
-import { Card } from '../../components/ui';
-import { SignInForm } from '../../components/auth/SignInForm';
+import nextDynamic from 'next/dynamic';
+import { Card } from '../../components/ui/Card';
+
+export const dynamic = 'force-dynamic';
+
+const SignInForm = nextDynamic(
+  () => import('../../components/auth/SignInForm').then(mod => mod.SignInForm),
+  { ssr: false }
+);
 
 export default function MarketingPage() {
   return (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,58 +1,178 @@
 'use client';
 
-import React from 'react';
-import { Card } from '../../components/ui';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, Button } from '../../components/ui';
 import { useAuth } from '../../components/auth/AuthProvider';
-import { Button } from '../../components/ui';
+import {
+  listSessions,
+  onSessionsChanged,
+  SessionRecord,
+} from '../../lib/sessions';
+import { getTechniqueByKey } from '../../lib/techniques';
+import Link from 'next/link';
+
+type Summary = {
+  totalMinutes: number;
+  streak: number;
+};
+
+function computeSummary(sessions: SessionRecord[]): Summary {
+  const totalMinutes = sessions.reduce((total, session) => {
+    const technique = getTechniqueByKey(session.techniqueKey);
+    return total + (technique?.defaultDurationMinutes ?? 5);
+  }, 0);
+
+  const dayKey = (value: string) => new Date(value).toISOString().split('T')[0];
+  const uniqueDays = new Set(
+    sessions.map(session => dayKey(session.startedAt))
+  );
+
+  if (uniqueDays.size === 0) {
+    return { totalMinutes, streak: 0 };
+  }
+
+  const today = new Date();
+  const previousDay = (date: Date) => {
+    const next = new Date(date);
+    next.setDate(date.getDate() - 1);
+    next.setHours(0, 0, 0, 0);
+    return next;
+  };
+
+  const formatDay = (date: Date) => date.toISOString().split('T')[0];
+
+  let current = uniqueDays.has(formatDay(today)) ? today : previousDay(today);
+  let streak = 0;
+
+  while (uniqueDays.has(formatDay(current))) {
+    streak += 1;
+    current = previousDay(current);
+  }
+
+  return { totalMinutes, streak };
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  return new Intl.DateTimeFormat('en', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
 
 export default function DashboardPage() {
   const { user, signOut } = useAuth();
+  const router = useRouter();
+  const [sessions, setSessions] = useState<SessionRecord[]>([]);
+
+  useEffect(() => {
+    const sync = () => setSessions(listSessions());
+    sync();
+
+    const unsubscribe = onSessionsChanged(sync);
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  const summary = useMemo(() => computeSummary(sessions), [sessions]);
+  const recentSessions = useMemo(() => sessions.slice(0, 5), [sessions]);
 
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
-      <div className="max-w-4xl mx-auto">
-        <div className="flex justify-between items-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">
-            Dashboard
-          </h1>
-          <div className="flex items-center space-x-4">
-            <span className="text-sm text-gray-600">
+    <div className='min-h-screen bg-gray-50 p-8'>
+      <div className='max-w-4xl mx-auto'>
+        <div className='flex flex-col gap-4 md:flex-row md:items-center md:justify-between mb-8'>
+          <h1 className='text-3xl font-bold text-gray-900'>Dashboard</h1>
+          <div className='flex flex-col items-start gap-2 md:flex-row md:items-center md:gap-4'>
+            <span className='text-sm text-gray-600'>
               Welcome, {user?.email}
             </span>
-            <Button variant="outline" onClick={signOut}>
+            <Button variant='outline' onClick={signOut}>
               Sign Out
             </Button>
           </div>
         </div>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <Card>
-            <h2 className="text-xl font-semibold mb-4">Recent Sessions</h2>
-            <p className="text-gray-600">No sessions yet</p>
+
+        <div className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>
+          <Card className='p-6 space-y-2'>
+            <h2 className='text-xl font-semibold'>Recent Sessions</h2>
+            {recentSessions.length === 0 ? (
+              <p className='text-gray-600'>No sessions yet</p>
+            ) : (
+              <ul className='space-y-2 text-sm text-gray-700'>
+                {recentSessions.map(session => {
+                  const technique = getTechniqueByKey(session.techniqueKey);
+                  return (
+                    <li
+                      key={session.id}
+                      className='flex items-start justify-between gap-3 rounded-lg border border-gray-100 bg-white px-3 py-2'
+                    >
+                      <div>
+                        <p className='font-semibold text-gray-900'>
+                          {technique?.name ?? 'Meditation'}
+                        </p>
+                        <p className='text-xs text-gray-500'>
+                          {formatDate(session.startedAt)} ·{' '}
+                          {session.decidedBy === 'guru'
+                            ? 'Guru choice'
+                            : 'Your pick'}
+                        </p>
+                      </div>
+                      <Link
+                        className='text-xs font-semibold text-blue-600 hover:underline'
+                        href={`/meditate/live/${session.id}?technique=${session.techniqueKey}&decidedBy=${session.decidedBy}`}
+                      >
+                        Revisit
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
           </Card>
-          
-          <Card>
-            <h2 className="text-xl font-semibold mb-4">Total Minutes</h2>
-            <p className="text-2xl font-bold text-blue-600">0</p>
+
+          <Card className='p-6 space-y-2'>
+            <h2 className='text-xl font-semibold'>Total Minutes</h2>
+            <p className='text-3xl font-bold text-blue-600'>
+              {summary.totalMinutes}
+            </p>
+            <p className='text-sm text-gray-500'>
+              Lifetime minutes meditated in this device.
+            </p>
           </Card>
-          
-          <Card>
-            <h2 className="text-xl font-semibold mb-4">Current Streak</h2>
-            <p className="text-2xl font-bold text-green-600">0 days</p>
+
+          <Card className='p-6 space-y-2'>
+            <h2 className='text-xl font-semibold'>Current Streak</h2>
+            <p className='text-3xl font-bold text-green-600'>
+              {summary.streak} days
+            </p>
+            <p className='text-sm text-gray-500'>
+              Consecutive days with at least one session.
+            </p>
           </Card>
         </div>
-        
-        <div className="mt-8">
-          <Card>
-            <h2 className="text-xl font-semibold mb-4">Start New Session</h2>
-            <p className="text-gray-600 mb-4">Ready to begin your meditation journey?</p>
-            <div className="space-x-4">
-              <button className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700">
+
+        <div className='mt-8'>
+          <Card className='p-6 space-y-4'>
+            <div>
+              <h2 className='text-xl font-semibold'>Start New Session</h2>
+              <p className='text-gray-600'>
+                Ready to begin your meditation journey?
+              </p>
+            </div>
+            <div className='flex flex-col gap-3 sm:flex-row'>
+              <Button onClick={() => router.push('/meditate')}>
                 Let Guru Decide
-              </button>
-              <button className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50">
+              </Button>
+              <Button
+                variant='outline'
+                onClick={() => router.push('/meditate#techniques')}
+              >
                 Pick Technique
-              </button>
+              </Button>
             </div>
           </Card>
         </div>

--- a/app/meditate/live/[sessionId]/page.tsx
+++ b/app/meditate/live/[sessionId]/page.tsx
@@ -1,32 +1,114 @@
 import React from 'react';
-import { Card } from '../../../../components/ui';
+import { Card, Button } from '../../../../components/ui';
+import { formatPattern, getTechniqueByKey } from '../../../../lib/techniques';
 
 interface LiveSessionPageProps {
   params: {
     sessionId: string;
   };
+  searchParams?: {
+    technique?: string;
+    decidedBy?: string;
+  };
 }
 
-export default function LiveSessionPage({ params }: LiveSessionPageProps) {
+export default function LiveSessionPage({
+  params,
+  searchParams,
+}: LiveSessionPageProps) {
   const { sessionId } = params;
+  const technique = getTechniqueByKey(searchParams?.technique);
+  const decidedBy = searchParams?.decidedBy === 'user' ? 'You' : 'Guru';
 
   return (
     <div className='min-h-screen bg-gray-50 p-8'>
-      <div className='max-w-3xl mx-auto space-y-6'>
+      <div className='max-w-4xl mx-auto space-y-6'>
         <header className='space-y-2 text-center'>
           <h1 className='text-3xl font-bold text-gray-900'>Live Session</h1>
           <p className='text-gray-600'>
-            Placeholder view for session{' '}
-            <span className='font-mono'>{sessionId}</span>
+            Session ID{' '}
+            <span className='font-mono text-sm text-gray-700 bg-gray-100 px-2 py-1 rounded'>
+              {sessionId}
+            </span>
           </p>
+          {technique && (
+            <p className='text-gray-500 text-sm'>
+              {decidedBy} selected{' '}
+              <span className='font-semibold'>{technique.name}</span> to guide
+              this practice.
+            </p>
+          )}
         </header>
 
-        <Card className='text-center text-gray-600'>
-          <p>
-            This page will host the real-time meditation experience. For now it
-            simply confirms the active session ID.
-          </p>
-        </Card>
+        {technique ? (
+          <Card className='space-y-4 p-6'>
+            <div className='space-y-1'>
+              <h2 className='text-2xl font-semibold text-gray-900'>
+                {technique.name}
+              </h2>
+              <p className='text-gray-600'>{technique.description}</p>
+              <p className='text-sm uppercase tracking-wide text-blue-600'>
+                Pattern: {formatPattern(technique.pattern)} ·{' '}
+                {technique.defaultDurationMinutes} min
+              </p>
+            </div>
+
+            <div className='grid gap-3 md:grid-cols-2'>
+              <Card className='border-blue-100 bg-blue-50 p-4'>
+                <h3 className='text-sm font-semibold text-blue-900 uppercase tracking-wide'>
+                  Intention
+                </h3>
+                <p className='text-blue-900 mt-1'>{technique.intention}</p>
+              </Card>
+
+              <Card className='border-green-100 bg-green-50 p-4'>
+                <h3 className='text-sm font-semibold text-green-900 uppercase tracking-wide'>
+                  Benefits
+                </h3>
+                <ul className='mt-1 list-disc space-y-1 pl-4 text-green-900'>
+                  {technique.benefits.map(benefit => (
+                    <li key={benefit}>{benefit}</li>
+                  ))}
+                </ul>
+              </Card>
+            </div>
+
+            <div className='space-y-2'>
+              <h3 className='text-sm font-semibold text-gray-900 uppercase tracking-wide'>
+                Guidance cues
+              </h3>
+              <ul className='list-disc space-y-1 pl-5 text-gray-700'>
+                {technique.cues.map(cue => (
+                  <li key={cue}>{cue}</li>
+                ))}
+              </ul>
+            </div>
+
+            <div className='flex flex-col gap-2 border-t border-gray-100 pt-4 md:flex-row md:items-center md:justify-between'>
+              <p className='text-sm text-gray-600'>
+                Stay present with the breath. When you are ready to wrap up, log
+                a reflection to save this session.
+              </p>
+              <div className='flex gap-2'>
+                <Button type='button' variant='outline'>
+                  Pause
+                </Button>
+                <Button type='button'>Log Reflection</Button>
+              </div>
+            </div>
+          </Card>
+        ) : (
+          <Card className='p-6 text-center text-gray-600'>
+            <p>
+              This session is ready, but a technique was not provided. Head back
+              to{' '}
+              <a href='/meditate' className='text-blue-600 hover:underline'>
+                the meditation lobby
+              </a>{' '}
+              to choose one.
+            </p>
+          </Card>
+        )}
       </div>
     </div>
   );

--- a/app/meditate/page.tsx
+++ b/app/meditate/page.tsx
@@ -1,10 +1,124 @@
-import { Card } from '../../components/ui';
-import { Button } from '../../components/ui';
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, Button } from '../../components/ui';
+import {
+  chooseTechniqueForProfile,
+  formatPattern,
+  getTechniqueByKey,
+  listTechniques,
+  Goal,
+  Mood,
+} from '../../lib/techniques';
+import { createSession } from '../../lib/sessions';
+
+const moodOptions: { label: string; value: Mood; description: string }[] = [
+  {
+    label: 'Stressed',
+    value: 'stressed',
+    description: 'Mind racing, need grounding',
+  },
+  {
+    label: 'Tired',
+    value: 'tired',
+    description: 'Low energy, craving warmth',
+  },
+  {
+    label: 'Restless',
+    value: 'restless',
+    description: 'Fidgety or overstimulated',
+  },
+];
+
+const goalOptions: { label: string; value: Goal; description: string }[] = [
+  {
+    label: 'Find Calm',
+    value: 'calm',
+    description: 'Settle nerves and create ease',
+  },
+  {
+    label: 'Sleep Better',
+    value: 'sleep',
+    description: 'Wind down before rest',
+  },
+  {
+    label: 'Sharpen Focus',
+    value: 'focus',
+    description: 'Prepare to dive into deep work',
+  },
+  {
+    label: 'Open the Heart',
+    value: 'self_love',
+    description: 'Cultivate compassion and warmth',
+  },
+];
 
 export default function MeditatePage() {
+  const router = useRouter();
+  const [mood, setMood] = useState<Mood>('stressed');
+  const [goal, setGoal] = useState<Goal>('calm');
+  const [techniqueKey, setTechniqueKey] = useState('');
+  const [isGuruSelecting, setIsGuruSelecting] = useState(false);
+  const [isUserStarting, setIsUserStarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const techniques = useMemo(() => listTechniques(), []);
+  const selectedTechnique = useMemo(
+    () => getTechniqueByKey(techniqueKey),
+    [techniqueKey]
+  );
+
+  const handleGuruDecide = async () => {
+    setIsGuruSelecting(true);
+    setError(null);
+
+    try {
+      const technique = chooseTechniqueForProfile({ mood, goal });
+      const session = createSession({
+        decidedBy: 'guru',
+        techniqueKey: technique.key,
+        metadata: { mood, goal },
+      });
+
+      router.push(
+        `/meditate/live/${session.id}?technique=${technique.key}&decidedBy=guru`
+      );
+    } catch (err) {
+      setError('Something went wrong while starting your session.');
+    } finally {
+      setIsGuruSelecting(false);
+    }
+  };
+
+  const handleTechniqueStart = () => {
+    if (!selectedTechnique) {
+      setError('Please pick a technique to continue.');
+      return;
+    }
+
+    setIsUserStarting(true);
+    setError(null);
+
+    try {
+      const session = createSession({
+        decidedBy: 'user',
+        techniqueKey: selectedTechnique.key,
+      });
+
+      router.push(
+        `/meditate/live/${session.id}?technique=${selectedTechnique.key}&decidedBy=user`
+      );
+    } catch (err) {
+      setError('Unable to start the selected technique.');
+    } finally {
+      setIsUserStarting(false);
+    }
+  };
+
   return (
     <div className='min-h-screen bg-gray-50 p-8'>
-      <div className='max-w-3xl mx-auto space-y-8'>
+      <div className='max-w-4xl mx-auto space-y-8'>
         <header className='text-center space-y-2'>
           <h1 className='text-3xl font-bold text-gray-900'>
             Start a Meditation
@@ -14,51 +128,164 @@ export default function MeditatePage() {
           </p>
         </header>
 
-        <div className='grid gap-6 md:grid-cols-2'>
-          <Card className='flex flex-col h-full justify-between space-y-4'>
-            <div className='space-y-2'>
-              <h2 className='text-xl font-semibold text-gray-900'>
-                Let Guru Decide
-              </h2>
-              <p className='text-gray-600'>
-                Answer a quick check-in and let the AI Guru pick the right
-                meditation technique for you.
-              </p>
-            </div>
-            <div className='space-y-2'>
-              <Button type='button' className='w-full' disabled>
-                Let Guru Decide
-              </Button>
-              <p className='text-sm text-gray-500 text-center'>
-                Flow coming soon
-              </p>
-            </div>
-          </Card>
+        {error && (
+          <div className='bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg'>
+            {error}
+          </div>
+        )}
 
-          <Card className='flex flex-col h-full justify-between space-y-4'>
-            <div className='space-y-2'>
-              <h2 className='text-xl font-semibold text-gray-900'>
-                Pick Technique
-              </h2>
-              <p className='text-gray-600'>
-                Browse the catalog of meditation styles and jump directly into a
-                live session.
-              </p>
+        <div className='grid gap-6 lg:grid-cols-2'>
+          <Card className='flex flex-col h-full justify-between space-y-4 p-6'>
+            <div className='space-y-4'>
+              <div>
+                <h2 className='text-xl font-semibold text-gray-900'>
+                  Let Guru Decide
+                </h2>
+                <p className='text-gray-600'>
+                  Answer a quick check-in and let the AI Guru pick the right
+                  meditation technique for you.
+                </p>
+              </div>
+
+              <div className='space-y-3'>
+                <div>
+                  <p className='text-sm font-medium text-gray-700 mb-2'>
+                    How are you arriving?
+                  </p>
+                  <div className='grid sm:grid-cols-3 gap-2'>
+                    {moodOptions.map(option => (
+                      <button
+                        key={option.value}
+                        type='button'
+                        onClick={() => setMood(option.value)}
+                        className={`rounded-lg border px-3 py-2 text-sm text-left transition-colors ${
+                          mood === option.value
+                            ? 'border-blue-500 bg-blue-50 text-blue-700'
+                            : 'border-gray-200 bg-white hover:border-blue-300'
+                        }`}
+                      >
+                        <span className='font-semibold block'>
+                          {option.label}
+                        </span>
+                        <span className='text-xs text-gray-600'>
+                          {option.description}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <p className='text-sm font-medium text-gray-700 mb-2'>
+                    What do you need most?
+                  </p>
+                  <div className='grid sm:grid-cols-2 gap-2'>
+                    {goalOptions.map(option => (
+                      <button
+                        key={option.value}
+                        type='button'
+                        onClick={() => setGoal(option.value)}
+                        className={`rounded-lg border px-3 py-2 text-sm text-left transition-colors ${
+                          goal === option.value
+                            ? 'border-blue-500 bg-blue-50 text-blue-700'
+                            : 'border-gray-200 bg-white hover:border-blue-300'
+                        }`}
+                      >
+                        <span className='font-semibold block'>
+                          {option.label}
+                        </span>
+                        <span className='text-xs text-gray-600'>
+                          {option.description}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
             </div>
+
             <div className='space-y-2'>
               <Button
                 type='button'
                 className='w-full'
-                variant='outline'
-                disabled
+                onClick={handleGuruDecide}
+                disabled={isGuruSelecting}
               >
-                Pick Technique
+                {isGuruSelecting ? 'Finding your session…' : 'Let Guru Decide'}
               </Button>
               <p className='text-sm text-gray-500 text-center'>
-                Technique picker under construction
+                We suggest a technique based on your mood and intention.
               </p>
             </div>
           </Card>
+
+          <div id='techniques'>
+            <Card className='flex flex-col h-full justify-between space-y-4 p-6'>
+              <div className='space-y-4'>
+                <div>
+                  <h2 className='text-xl font-semibold text-gray-900'>
+                    Pick Technique
+                  </h2>
+                  <p className='text-gray-600'>
+                    Browse the catalog of meditation styles and jump directly
+                    into a live session.
+                  </p>
+                </div>
+
+                <div className='space-y-3'>
+                  <label className='block text-sm font-medium text-gray-700'>
+                    Choose a technique
+                    <select
+                      value={techniqueKey}
+                      onChange={event => setTechniqueKey(event.target.value)}
+                      className='mt-2 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200'
+                    >
+                      <option value=''>Select...</option>
+                      {techniques.map(technique => (
+                        <option key={technique.key} value={technique.key}>
+                          {technique.name} · {technique.defaultDurationMinutes}{' '}
+                          min
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  {selectedTechnique && (
+                    <div className='rounded-lg border border-blue-100 bg-blue-50 p-4 text-sm text-blue-900 space-y-2'>
+                      <p className='font-semibold'>{selectedTechnique.name}</p>
+                      <p>{selectedTechnique.description}</p>
+                      <p className='text-xs uppercase tracking-wide text-blue-600'>
+                        Pattern: {formatPattern(selectedTechnique.pattern)}
+                      </p>
+                      <ul className='list-disc pl-5 space-y-1'>
+                        {selectedTechnique.benefits.map(benefit => (
+                          <li key={benefit}>{benefit}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className='space-y-2'>
+                <Button
+                  type='button'
+                  className='w-full'
+                  variant='outline'
+                  onClick={handleTechniqueStart}
+                  disabled={!selectedTechnique || isUserStarting}
+                >
+                  {isUserStarting
+                    ? 'Preparing session…'
+                    : 'Start with this technique'}
+                </Button>
+                <p className='text-sm text-gray-500 text-center'>
+                  You can always switch techniques once you are in the live
+                  room.
+                </p>
+              </div>
+            </Card>
+          </div>
         </div>
       </div>
     </div>

--- a/components/auth/AuthProvider.tsx
+++ b/components/auth/AuthProvider.tsx
@@ -23,7 +23,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     // Get initial session
     const getInitialSession = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
       setSession(session);
       setUser(session?.user ?? null);
       setLoading(false);
@@ -32,13 +34,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     getInitialSession();
 
     // Listen for auth changes
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      async (event, session) => {
-        setSession(session);
-        setUser(session?.user ?? null);
-        setLoading(false);
-      }
-    );
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(async (_event, session) => {
+      setSession(session);
+      setUser(session?.user ?? null);
+      setLoading(false);
+    });
 
     return () => subscription.unsubscribe();
   }, []);
@@ -55,11 +57,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     signOut,
   };
 
-  return (
-    <AuthContext.Provider value={value}>
-      {children}
-    </AuthContext.Provider>
-  );
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 export function useAuth() {

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -6,29 +8,31 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
 }
 
-export function Button({ 
-  variant = 'primary', 
-  size = 'md', 
-  children, 
-  className = '', 
-  ...props 
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  children,
+  className = '',
+  ...props
 }: ButtonProps) {
-  const baseClasses = 'font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
-  
+  const baseClasses =
+    'font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
+
   const variantClasses = {
     primary: 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500',
     secondary: 'bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500',
-    outline: 'border border-gray-300 text-gray-700 hover:bg-gray-50 focus:ring-blue-500',
+    outline:
+      'border border-gray-300 text-gray-700 hover:bg-gray-50 focus:ring-blue-500',
   };
-  
+
   const sizeClasses = {
     sm: 'px-3 py-1.5 text-sm',
     md: 'px-4 py-2 text-base',
     lg: 'px-6 py-3 text-lg',
   };
-  
+
   const classes = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${className}`;
-  
+
   return (
     <button className={classes} {...props}>
       {children}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 interface CardProps {
@@ -6,24 +8,16 @@ interface CardProps {
   padding?: 'sm' | 'md' | 'lg';
 }
 
-export function Card({ 
-  children, 
-  className = '', 
-  padding = 'md' 
-}: CardProps) {
+export function Card({ children, className = '', padding = 'md' }: CardProps) {
   const baseClasses = 'bg-white rounded-lg border border-gray-200 shadow-sm';
-  
+
   const paddingClasses = {
     sm: 'p-4',
     md: 'p-6',
     lg: 'p-8',
   };
-  
+
   const classes = `${baseClasses} ${paddingClasses[padding]} ${className}`;
-  
-  return (
-    <div className={classes}>
-      {children}
-    </div>
-  );
+
+  return <div className={classes}>{children}</div>;
 }

--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -1,0 +1,111 @@
+import { TechniqueKey } from './techniques';
+
+export type SessionDecision = 'guru' | 'user';
+
+export interface SessionRecord {
+  id: string;
+  techniqueKey: TechniqueKey;
+  decidedBy: SessionDecision;
+  startedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+const STORAGE_KEY = 'guru.sessions';
+const UPDATE_EVENT = 'guru:sessions-updated';
+
+let inMemorySessions: SessionRecord[] = [];
+
+function isBrowser(): boolean {
+  return (
+    typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+  );
+}
+
+function readSessions(): SessionRecord[] {
+  if (isBrowser()) {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return [];
+      }
+
+      const parsed = JSON.parse(raw) as SessionRecord[];
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed;
+    } catch (error) {
+      return [];
+    }
+  }
+
+  return inMemorySessions;
+}
+
+function persistSessions(sessions: SessionRecord[]): void {
+  if (isBrowser()) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions));
+  }
+  inMemorySessions = sessions;
+
+  if (isBrowser()) {
+    window.dispatchEvent(new CustomEvent(UPDATE_EVENT));
+  }
+}
+
+export interface CreateSessionInput {
+  techniqueKey: TechniqueKey;
+  decidedBy: SessionDecision;
+  metadata?: Record<string, unknown>;
+}
+
+export function createSession(input: CreateSessionInput): SessionRecord {
+  const session: SessionRecord = {
+    id:
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : Date.now().toString(36),
+    techniqueKey: input.techniqueKey,
+    decidedBy: input.decidedBy,
+    metadata: input.metadata,
+    startedAt: new Date().toISOString(),
+  };
+
+  const sessions = readSessions();
+  const updated = [...sessions, session];
+  persistSessions(updated);
+  return session;
+}
+
+export function listSessions(): SessionRecord[] {
+  const sessions = readSessions();
+  return [...sessions].sort((a, b) => {
+    return new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime();
+  });
+}
+
+export function onSessionsChanged(callback: () => void): () => void {
+  if (!isBrowser()) {
+    return () => undefined;
+  }
+
+  const handleUpdate = () => callback();
+  const handleStorage = (event: StorageEvent) => {
+    if (!event.key || event.key === STORAGE_KEY) {
+      callback();
+    }
+  };
+
+  window.addEventListener(UPDATE_EVENT, handleUpdate);
+  window.addEventListener('storage', handleStorage);
+
+  return () => {
+    window.removeEventListener(UPDATE_EVENT, handleUpdate);
+    window.removeEventListener('storage', handleStorage);
+  };
+}
+
+export function clearSessions(): void {
+  persistSessions([]);
+}

--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -68,8 +68,8 @@ export function createSession(input: CreateSessionInput): SessionRecord {
         : Date.now().toString(36),
     techniqueKey: input.techniqueKey,
     decidedBy: input.decidedBy,
-    metadata: input.metadata,
     startedAt: new Date().toISOString(),
+    ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
   };
 
   const sessions = readSessions();

--- a/lib/techniques.ts
+++ b/lib/techniques.ts
@@ -1,0 +1,225 @@
+export type TechniqueKey =
+  | 'box_breathing'
+  | 'body_scan'
+  | 'mindfulness'
+  | 'loving_kindness'
+  | 'nadi_shodhana';
+
+type BreathPattern = {
+  inhale: number;
+  hold?: number;
+  exhale: number;
+  cycles?: number;
+};
+
+export interface Technique {
+  key: TechniqueKey;
+  name: string;
+  description: string;
+  intention: string;
+  defaultDurationMinutes: number;
+  benefits: string[];
+  pattern: BreathPattern;
+  cues: string[];
+}
+
+const TECHNIQUES: Technique[] = [
+  {
+    key: 'box_breathing',
+    name: 'Box Breathing',
+    description:
+      'Steady, four-part breathing to settle the nervous system and restore balance.',
+    intention: 'Find calm and focus in just a few minutes.',
+    defaultDurationMinutes: 5,
+    benefits: [
+      'Stabilises the heart rate',
+      'Clears mental fog',
+      'Creates a sense of grounded presence',
+    ],
+    pattern: {
+      inhale: 4,
+      hold: 4,
+      exhale: 4,
+      cycles: 12,
+    },
+    cues: [
+      'Inhale smoothly for four counts',
+      'Hold with soft shoulders',
+      'Exhale fully and evenly',
+      'Pause briefly before the next round',
+    ],
+  },
+  {
+    key: 'body_scan',
+    name: 'Body Scan',
+    description:
+      'A gentle tour through the body that softens tension and invites deep rest.',
+    intention: 'Release the day and prepare for nourishing sleep.',
+    defaultDurationMinutes: 12,
+    benefits: [
+      'Eases physical tightness',
+      'Calms racing thoughts',
+      'Supports better sleep quality',
+    ],
+    pattern: {
+      inhale: 5,
+      exhale: 5,
+    },
+    cues: [
+      'Notice contact points with the ground',
+      'Scan slowly from toes to crown',
+      'Breathe into any sensations that arise',
+      'Let heaviness melt into the earth',
+    ],
+  },
+  {
+    key: 'mindfulness',
+    name: 'Mindful Breathing',
+    description:
+      'Rest in the simplicity of natural breath while observing thoughts without judgement.',
+    intention: 'Cultivate steady awareness and a spacious mind.',
+    defaultDurationMinutes: 8,
+    benefits: [
+      'Enhances focus',
+      'Reduces stress reactivity',
+      'Builds emotional clarity',
+    ],
+    pattern: {
+      inhale: 4,
+      exhale: 6,
+    },
+    cues: [
+      'Rest attention on the tip of the nose',
+      'Let the breath be easy and unforced',
+      'Label distractions gently',
+      'Return kindly to the next inhale',
+    ],
+  },
+  {
+    key: 'loving_kindness',
+    name: 'Loving Kindness',
+    description:
+      'Nurture warmth and compassion through affirmations for yourself and others.',
+    intention: 'Open the heart and reconnect with kindness.',
+    defaultDurationMinutes: 10,
+    benefits: [
+      'Increases positive emotion',
+      'Softens self-criticism',
+      'Strengthens connection to others',
+    ],
+    pattern: {
+      inhale: 4,
+      exhale: 6,
+    },
+    cues: [
+      'Anchor in the breath for a few rounds',
+      'Repeat phrases like “May I be at ease”',
+      'Extend the wishes to someone you love',
+      'Radiate the well-wishing outward',
+    ],
+  },
+  {
+    key: 'nadi_shodhana',
+    name: 'Alternate Nostril Breath',
+    description:
+      'Balance the subtle energy channels with alternating nasal breathing.',
+    intention: 'Reset when feeling scattered or overstimulated.',
+    defaultDurationMinutes: 6,
+    benefits: [
+      'Balances nervous system',
+      'Clears lingering agitation',
+      'Brightens concentration',
+    ],
+    pattern: {
+      inhale: 4,
+      hold: 2,
+      exhale: 4,
+      cycles: 10,
+    },
+    cues: [
+      'Use the right thumb to close the right nostril',
+      'Breathe in through the left, then switch',
+      'Keep the shoulders relaxed',
+      'Finish with a deep, even breath through both nostrils',
+    ],
+  },
+];
+
+export function getTechniqueByKey(
+  key: string | null | undefined
+): Technique | null {
+  if (!key) {
+    return null;
+  }
+
+  return TECHNIQUES.find(technique => technique.key === key) ?? null;
+}
+
+export function listTechniques(): Technique[] {
+  return [...TECHNIQUES];
+}
+
+export type Mood = 'stressed' | 'tired' | 'restless';
+export type Goal = 'calm' | 'sleep' | 'focus' | 'self_love';
+
+export interface GuruProfile {
+  mood: Mood;
+  goal: Goal;
+}
+
+export function chooseTechniqueForProfile(profile: GuruProfile): Technique {
+  const priorityKeys: TechniqueKey[] = [];
+
+  switch (profile.goal) {
+    case 'sleep':
+      priorityKeys.push('body_scan');
+      break;
+    case 'focus':
+      priorityKeys.push('box_breathing', 'mindfulness');
+      break;
+    case 'self_love':
+      priorityKeys.push('loving_kindness');
+      break;
+    default:
+      priorityKeys.push('mindfulness');
+      break;
+  }
+
+  switch (profile.mood) {
+    case 'tired':
+      priorityKeys.push('loving_kindness', 'mindfulness');
+      break;
+    case 'restless':
+      priorityKeys.push('nadi_shodhana', 'box_breathing');
+      break;
+    default:
+      priorityKeys.push('box_breathing');
+      break;
+  }
+
+  for (const key of priorityKeys) {
+    const match = getTechniqueByKey(key);
+    if (match) {
+      return match;
+    }
+  }
+
+  return pickRandomTechnique();
+}
+
+export function pickRandomTechnique(): Technique {
+  const index = Math.floor(Math.random() * TECHNIQUES.length);
+  return TECHNIQUES[index];
+}
+
+export function formatPattern(pattern: BreathPattern): string {
+  const parts = [`Inhale ${pattern.inhale}s`];
+  if (pattern.hold) {
+    parts.push(`Hold ${pattern.hold}s`);
+  }
+  parts.push(`Exhale ${pattern.exhale}s`);
+  if (pattern.cycles) {
+    parts.push(`${pattern.cycles} cycles`);
+  }
+  return parts.join(' • ');
+}

--- a/lib/techniques.ts
+++ b/lib/techniques.ts
@@ -208,8 +208,15 @@ export function chooseTechniqueForProfile(profile: GuruProfile): Technique {
 }
 
 export function pickRandomTechnique(): Technique {
+  if (TECHNIQUES.length === 0) {
+    throw new Error('No techniques available to choose from.');
+  }
   const index = Math.floor(Math.random() * TECHNIQUES.length);
-  return TECHNIQUES[index];
+  const technique = TECHNIQUES[index];
+  if (!technique) {
+    throw new Error('Failed to select a technique.');
+  }
+  return technique;
 }
 
 export function formatPattern(pattern: BreathPattern): string {


### PR DESCRIPTION
## Summary
- add a local catalogue of meditation techniques with session helpers
- wire the /meditate lobby to create sessions and navigate into the live view
- refresh the dashboard to show local session history and quick-start actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dccbd1b94883319a82661d5b786b7e