### PR TITLE
Fix marketing page routing

### DIFF
--- a/app/(marketing)/marketing/page.tsx
+++ b/app/(marketing)/marketing/page.tsx
@@ -2,12 +2,12 @@
 
 import React from 'react';
 import nextDynamic from 'next/dynamic';
-import { Card } from '../../components/ui/Card';
+import { Card } from '@/components/ui/Card';
 
 export const dynamic = 'force-dynamic';
 
 const SignInForm = nextDynamic(
-  () => import('../../components/auth/SignInForm').then(mod => mod.SignInForm),
+  () => import('@/components/auth/SignInForm').then(mod => mod.SignInForm),
   { ssr: false }
 );
 


### PR DESCRIPTION
## Summary
- move the marketing page into an explicit /marketing route so redirects resolve correctly
- switch marketing page imports to use the @ alias for shared components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df6527f8fc83318b9fcc26cd939e64