### PR TITLE
Fix magic link redirect to use configured site URL

### DIFF
--- a/components/auth/SignInForm.tsx
+++ b/components/auth/SignInForm.tsx
@@ -17,10 +17,14 @@ export function SignInForm() {
 
     try {
       const supabase = createClient();
+      const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? '').trim();
+      const redirectOrigin = siteUrl
+        ? siteUrl.replace(/\/$/, '')
+        : window.location.origin;
       const { error } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`,
+          emailRedirectTo: `${redirectOrigin}/auth/callback`,
         },
       });
 


### PR DESCRIPTION
## Summary
- ensure the Supabase magic link redirect uses the configured public site URL when available
- fall back to the browser origin only when an explicit site URL is not provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d74f29548331a9b09b30ab474772